### PR TITLE
formatted script

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -64,6 +64,14 @@ for each in 1 4 8 16 32 64;
 		sleep 30; 
 	done
 
+echo "###Read/Write Requests Per Second###"
+grep "read/write requests:" test.txt | tr -d '()' | awk '{print $4}'
+
+echo
+
+echo "###Transactions Per Second###"
+grep "transactions:" test.txt | tr -d '()' | awk '{print $3}'
+
 sync
 
 fio --time_based --name=benchmark --size=8G --runtime=300 --filename=rand --ioengine=libaio --randrepeat=0 --iodepth=32 --direct=1 --invalidate=1 --verify=0 --verify_fatal=0 --numjobs=4 --rw=randwrite --blocksize=4k --group_reporting

--- a/bench.sh
+++ b/bench.sh
@@ -22,7 +22,7 @@ echo "Starting Random Write Sysbench Test"
 for each in 1 4 8 16 32 64; 
 	do 
 		echo "Starting $each thread Random Write"
-		sysbench --test=fileio --file-total-size=8G --file-test-mode=rndwr --max-time=300 --max-requests=0 --file-block-size=4K --num-threads=$each --file-extra-flags=direct run >> ./$each-thread-randWrite-results; 
+		sysbench --test=fileio --file-total-size=8G --file-test-mode=rndwr --max-time=300 --max-requests=0 --file-block-size=4K --num-threads=$each --file-extra-flags=direct run >> ./randWrite-results; 
 		sleep 10; 
 	done
 	
@@ -41,7 +41,7 @@ echo "Starting Random Read Sysbench Test"
 for each in 1 4 8 16 32 64; 
 	do 
 		echo "Starting $each thread Random Read"
-		sysbench --test=fileio --file-total-size=8G --file-test-mode=rndrd --max-time=300 --max-requests=0 --file-block-size=4K --num-threads=$each --file-extra-flags=direct run >> ./$each-thread-randRead-results; 
+		sysbench --test=fileio --file-total-size=8G --file-test-mode=rndrd --max-time=300 --max-requests=0 --file-block-size=4K --num-threads=$each --file-extra-flags=direct run >> ./randRead-results; 
 		sleep 10; 
 	done 
 	


### PR DESCRIPTION
bumped test time to 5 minutes,

sent sysbench results into files for better readability, searching and storage

replaced rm -f command with sysbench cleanup command

Added some output cleaning code for easier copy pasta
